### PR TITLE
Add save/load support for ploidy classifier models

### DIFF
--- a/popopolus/classify_ploidy/logistic_regression.py
+++ b/popopolus/classify_ploidy/logistic_regression.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any, Sequence
 
+import joblib
 import numpy as np
 import pandas as pd
 from sklearn.linear_model import LogisticRegression
@@ -440,6 +442,56 @@ def prepare_feature_columns(
     return features, labels
 
 
+def save_model(
+    model: Pipeline,
+    path: str | Path,
+    *,
+    feature_columns: Sequence[str] | None = None,
+) -> Path:
+    """Persist a trained pipeline and its metadata to disk.
+
+    The model is saved as a joblib file.  A companion JSON sidecar
+    (``<stem>.meta.json``) stores the feature column names so that a
+    loaded model can be applied to new data without the caller needing
+    to know which columns were used during training.
+    """
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    joblib.dump(model, path)
+
+    meta: dict[str, Any] = {}
+    if feature_columns is not None:
+        meta["feature_columns"] = list(feature_columns)
+    elif hasattr(model, "feature_names_in_"):
+        meta["feature_columns"] = list(model.feature_names_in_)
+
+    meta_path = path.with_suffix(".meta.json")
+    meta_path.write_text(json.dumps(meta, indent=2))
+    return path
+
+
+def load_model(
+    path: str | Path,
+) -> tuple[Pipeline, list[str] | None]:
+    """Load a previously saved pipeline and optional feature metadata.
+
+    Returns the model and, when available, the list of feature column
+    names that were used during training.
+    """
+
+    path = Path(path)
+    model = joblib.load(path)
+
+    feature_columns: list[str] | None = None
+    meta_path = path.with_suffix(".meta.json")
+    if meta_path.exists():
+        meta = json.loads(meta_path.read_text())
+        feature_columns = meta.get("feature_columns")
+
+    return model, feature_columns
+
+
 def build_logistic_regression_pipeline(
     *,
     scale: bool = True,
@@ -709,12 +761,54 @@ def logistic_regression(
     sample_sheet: str | Path | pd.DataFrame,
     vcf_file: str | Path,
     output_dir: str | Path = "dummy",
+    model_path: str | Path | None = None,
 ) -> pd.DataFrame:
-    """Train on labeled samples and predict ploidy from VCF-derived features."""
+    """Train on labeled samples and predict ploidy from VCF-derived features.
+
+    Parameters
+    ----------
+    model_path : str or Path, optional
+        Path to a pre-trained model saved with :func:`save_model`.  When
+        provided the model is loaded from disk and used directly for
+        prediction, skipping training and cross-validation.  When *not*
+        provided, a new model is trained from the labeled samples in
+        *sample_sheet* and saved to *output_dir* (if given).
+    """
 
     feature_df = extract_allele_balance_features(vcf_file)
     label_df = _load_label_table(sample_sheet)
 
+    # ------------------------------------------------------------------
+    # Pre-trained model path supplied – load and predict only
+    # ------------------------------------------------------------------
+    if model_path is not None:
+        model, saved_feature_columns = load_model(model_path)
+
+        prediction_df = generate_predictions(
+            model,
+            feature_df,
+            feature_columns=saved_feature_columns,
+            fill_value=0.0,
+        )
+        prediction_df = prediction_df.rename(columns={"predicted_label": "predicted_ploidy"})
+
+        results_df = feature_df.join(
+            label_df[[DEFAULT_LABEL_COLUMN]].rename(
+                columns={DEFAULT_LABEL_COLUMN: "known_ploidy"}
+            ),
+            how="left",
+        ).join(prediction_df)
+
+        if output_dir != "dummy":
+            output_path = Path(output_dir) / "logistic_regression_predictions.csv"
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            results_df.to_csv(output_path)
+
+        return results_df
+
+    # ------------------------------------------------------------------
+    # No pre-trained model – train from scratch
+    # ------------------------------------------------------------------
     merged_df = feature_df.join(label_df[[DEFAULT_LABEL_COLUMN]], how="left")
     training_df = merged_df[merged_df[DEFAULT_LABEL_COLUMN].notna()].copy()
     if training_df.empty:
@@ -748,10 +842,6 @@ def logistic_regression(
     print(cv_results["confusion_matrix"])
     print("Accuracy Stats:")
     print(cv_results["accuracy_df"])
-    #print(f'Accuracy: {cv_results["accuracy"]}'
-    #      f'Balanced Accuracy: {cv_results["balanced_accuracy"]}'
-    #      f'Macro F1: {cv_results["macro_f1"]}'
-    #      f'Weighted F1: {cv_results["weighted_f1"]}')
     ####
 
     ####
@@ -769,6 +859,11 @@ def logistic_regression(
         accuracy_df_path = Path(output_dir) / "logistic_regression_cv_accuracy.csv"
         accuracy_df_path.parent.mkdir(parents=True, exist_ok=True)
         cv_results["accuracy_df"].to_csv(accuracy_df_path)
+
+        # Save the trained model for future re-use
+        model_save_path = Path(output_dir) / "logistic_regression_model.joblib"
+        save_model(model, model_save_path, feature_columns=list(train_features.columns))
+        print(f"Trained model saved to {model_save_path}")
     ####
 
     return results_df
@@ -787,8 +882,10 @@ __all__ = [
     "extract_allele_balance_features",
     "generate_predictions",
     "get_bin_columns",
+    "load_model",
     "logistic_regression",
     "prepare_feature_columns",
+    "save_model",
     "stratified_train_test_split",
     "train_logistic_regression_model",
 ]

--- a/popopolus_cli.py
+++ b/popopolus_cli.py
@@ -59,7 +59,11 @@ def cli():
 @click.option('-o', '--output_dir', type=str, default='dummy', required=False,
               help = 'name of the directory where . will be a matrix of allele frequencies'
 )
-def classify_ploidy(sample_sheet, vcf_file, output_dir):
+@click.option('-m', '--model', type=str, default=None, required=False,
+              help = 'path to a pre-trained model file (.joblib). When provided, '
+                     'the model is loaded and used for prediction without training.'
+)
+def classify_ploidy(sample_sheet, vcf_file, output_dir, model):
     from popopolus.classify_ploidy.logistic_regression import logistic_regression
 
     start_time = time.process_time()
@@ -68,8 +72,10 @@ def classify_ploidy(sample_sheet, vcf_file, output_dir):
     if (output_dir != 'dummy'):
         check_dir(output_dir)
         logging.info(f'Matrix of allele frequencies for each individual will be written to: {output_dir}')
+    if model is not None:
+        logging.info(f'Using pre-trained model from {model}')
 
-    ploidy_results = logistic_regression(sample_sheet, vcf_file, output_dir)
+    ploidy_results = logistic_regression(sample_sheet, vcf_file, output_dir, model_path=model)
     print(ploidy_results)
     end_time = time.process_time()
     logging.info(f'End at {end_time}')

--- a/test/classify_ploidy/test_save_load_model.py
+++ b/test/classify_ploidy/test_save_load_model.py
@@ -1,0 +1,73 @@
+import json
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from popopolus.classify_ploidy.logistic_regression import (
+    build_logistic_regression_pipeline,
+    generate_predictions,
+    load_model,
+    save_model,
+    train_logistic_regression_model,
+)
+
+
+@pytest.fixture()
+def trained_model_and_features():
+    """Return a small trained pipeline together with its training data."""
+    rng = np.random.default_rng(42)
+    n_samples = 40
+    features = pd.DataFrame(
+        {
+            "feat_a": rng.normal(size=n_samples),
+            "feat_b": rng.normal(size=n_samples),
+        },
+        index=[f"sample_{i}" for i in range(n_samples)],
+    )
+    labels = pd.Series(
+        [2] * 20 + [4] * 20,
+        index=features.index,
+        name="ploidy",
+    )
+    model = train_logistic_regression_model(features, labels)
+    return model, features, labels
+
+
+def test_save_creates_joblib_and_meta(tmp_path, trained_model_and_features):
+    model, features, _ = trained_model_and_features
+    model_path = tmp_path / "model.joblib"
+    save_model(model, model_path, feature_columns=list(features.columns))
+
+    assert model_path.exists()
+    meta_path = model_path.with_suffix(".meta.json")
+    assert meta_path.exists()
+    meta = json.loads(meta_path.read_text())
+    assert meta["feature_columns"] == ["feat_a", "feat_b"]
+
+
+def test_load_restores_identical_predictions(tmp_path, trained_model_and_features):
+    model, features, _ = trained_model_and_features
+    model_path = tmp_path / "model.joblib"
+    save_model(model, model_path, feature_columns=list(features.columns))
+
+    loaded_model, loaded_cols = load_model(model_path)
+
+    assert loaded_cols == ["feat_a", "feat_b"]
+
+    original_preds = model.predict(features)
+    loaded_preds = loaded_model.predict(features)
+    np.testing.assert_array_equal(original_preds, loaded_preds)
+
+
+def test_load_without_meta_returns_none_columns(tmp_path, trained_model_and_features):
+    model, _, _ = trained_model_and_features
+    model_path = tmp_path / "model.joblib"
+    save_model(model, model_path)
+
+    # Remove sidecar to simulate missing metadata
+    model_path.with_suffix(".meta.json").unlink()
+
+    loaded_model, loaded_cols = load_model(model_path)
+    assert loaded_cols is None
+    assert loaded_model is not None


### PR DESCRIPTION
## Summary
- Adds save_model and load_model helpers for trained ploidy classification pipelines.
- Persists feature-column metadata in a JSON sidecar so loaded models can align prediction inputs.
- Adds a classify-ploidy CLI --model option to reuse an existing joblib model without retraining.
- Saves newly trained logistic regression models into the output directory for future prediction runs.

## Why
This makes classify-ploidy workflows reusable across runs. Users can train once, keep the fitted model and feature metadata, then apply that model to new VCF-derived features without repeating cross-validation and training.

## Impact
- Training mode continues to generate predictions and CV outputs, and now also writes logistic_regression_model.joblib plus logistic_regression_model.meta.json when an output directory is provided.
- Prediction-only mode loads a saved model, skips training and CV, and writes logistic_regression_predictions.csv when an output directory is provided.
- The CLI now accepts -m/--model for prediction with a pre-trained model.

## Validation
- .venv/bin/python -m pytest test/classify_ploidy/test_save_load_model.py
- Result: 3 passed
